### PR TITLE
Add AI autofill and backend endpoint

### DIFF
--- a/api/extract.js
+++ b/api/extract.js
@@ -1,0 +1,42 @@
+import { Configuration, OpenAIApi } from 'openai';
+import express from 'express';
+
+const router = express.Router();
+
+const configuration = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+const openai = new OpenAIApi(configuration);
+
+router.post('/', async (req, res) => {
+  const { text } = req.body;
+  if (!text) {
+    return res.status(400).json({ error: 'No text provided' });
+  }
+  const prompt = `
+Extract as many of the following as possible from the text and output ONLY as JSON:
+projectTitle, companyName, siteAddress, siteContactName, siteContactPhone, crewSize, forkliftSize, trailerType, tractorType, workDescription
+
+If a value isn't present, leave it blank.
+
+Text:
+"""${text}"""
+
+JSON:
+`;
+  try {
+    const completion = await openai.createCompletion({
+      model: 'text-davinci-003',
+      prompt,
+      max_tokens: 250,
+      temperature: 0,
+    });
+    const match = completion.data.choices[0].text.match(/\{[\s\S]*\}/);
+    const parsed = match ? JSON.parse(match[0]) : {};
+    res.status(200).json(parsed);
+  } catch (e) {
+    res.status(500).json({ error: 'Extraction failed' });
+  }
+});
+
+export default router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "lucide-react": "^0.344.0",
+        "express": "^4.19.2",
         "openai": "^5.9.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "node server.js"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
+    "express": "^4.19.2",
     "openai": "^5.9.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,23 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import extractRouter from './api/extract.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+app.use(express.json());
+
+app.use('/api/extract', extractRouter);
+
+const distPath = path.join(__dirname, 'dist');
+app.use(express.static(distPath));
+app.get('*', (_, res) => {
+  res.sendFile(path.join(distPath, 'index.html'));
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,8 @@ const OmegaMorganQuoteForm: React.FC = () => {
 
   const [copied, setCopied] = useState(false);
   const [storageCalculation, setStorageCalculation] = useState<number>(0);
+  const [aiInput, setAiInput] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const forkliftOptions = [
     { value: '', label: 'Select Forklift Size' },
@@ -115,6 +117,28 @@ const OmegaMorganQuoteForm: React.FC = () => {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
+  const handleAIAutoFill = async () => {
+    if (!aiInput.trim()) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/extract', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: aiInput }),
+      });
+      const data = await res.json();
+      setFormData(prev => ({
+        ...prev,
+        ...Object.fromEntries(
+          Object.entries(data).filter(([k, v]) => v && v !== '')
+        ),
+      }));
+    } catch (e) {
+      alert('AI extraction failed');
+    }
+    setLoading(false);
+  };
+
   const generateEquipmentList = () => {
     const equipment = ['Gear truck'];
     
@@ -188,6 +212,25 @@ Omega Morgan`;
               <h1 className="text-4xl font-bold text-gray-800">Omega Morgan</h1>
             </div>
             <p className="text-xl text-gray-600">Quote Generator</p>
+          </div>
+
+          <div className="mb-8">
+            <label className="font-semibold block mb-2">Paste Project Details (AI will auto-fill):</label>
+            <textarea
+              rows={4}
+              className="w-full p-3 border border-gray-300 rounded-lg mb-2"
+              placeholder="Paste a client email, project scope, or job request here…"
+              value={aiInput}
+              onChange={(e) => setAiInput(e.target.value)}
+              disabled={loading}
+            />
+            <button
+              onClick={handleAIAutoFill}
+              disabled={loading || !aiInput.trim()}
+              className="px-4 py-2 rounded-lg text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+            >
+              {loading ? 'Filling…' : 'Auto-Fill'}
+            </button>
           </div>
 
           <div className="grid lg:grid-cols-2 gap-8">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,43 +1,10 @@
-import React, { useState } from 'react'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import OmegaMorganQuoteForm from './App';
+import './index.css';
 
-// ...your other imports
-
-const [aiInput, setAiInput] = useState('')
-const [loading, setLoading] = useState(false)
-
-// Add this function inside your component:
-const handleAIAutoFill = async () => {
-  if (!aiInput.trim()) return
-  setLoading(true)
-  try {
-    const res = await fetch('/api/extract', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text: aiInput })
-    })
-    const data = await res.json()
-    // For each field, if AI found it, update form state. If not, leave as-is.
-    setFormData(prev => ({ ...prev, ...Object.fromEntries(
-      Object.entries(data).filter(([k, v]) => v && v !== '')
-    ) }))
-  } catch (e) {
-    alert('AI extraction failed')
-  }
-  setLoading(false)
-}
-
-// In your JSX, above the form:
-<div style={{ marginBottom: 24 }}>
-  <label><b>Paste Project Details (AI will auto-fill):</b></label>
-  <textarea
-    rows={4}
-    style={{ width: '100%', marginBottom: 8 }}
-    placeholder="Paste a client email, project scope, or job request here…"
-    value={aiInput}
-    onChange={e => setAiInput(e.target.value)}
-    disabled={loading}
-  />
-  <button onClick={handleAIAutoFill} disabled={loading || !aiInput.trim()}>
-    {loading ? 'Filling…' : 'Auto-Fill'}
-  </button>
-</div>
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <OmegaMorganQuoteForm />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- create express server and API to extract fields with OpenAI
- integrate AI auto-fill in form with new textarea
- restore React entry point
- add express dependency and start script

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878485205348321a821ce694237cba0